### PR TITLE
removi el ignore en aws-exports.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ amplify/backend/.temp
 build/
 dist/
 node_modules/
-aws-exports.js
 awsconfiguration.json
 amplifyconfiguration.json
 amplifyconfiguration.dart


### PR DESCRIPTION
Hola Maru!! Voy a intentar modificar el .gitignore para que **si incluya** el archivo .src/aws-exports.js que lo necesita la aplicación para funcionar.

Si aceptas este Pull Request vas a poder hacer un "git pull" desde tu terminal y volver a subir el proyecto, ya con eso creo que se subiria con el archivo .src/aws-exports.js pero sino, lo podemos hablar por ws!